### PR TITLE
Add python2-empy due to a chroot error

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -18,6 +18,7 @@ makedepends=('cmake' 'ros-build-tools'
 
 ros_depends=()
 depends=(${ros_depends[@]}
+  'python2-empy'
   eigen3)
 
 # Git version (e.g. for debugging)


### PR DESCRIPTION
Building on a clean chroot, cmake report this error:
```
CMake Error at /opt/ros/melodic/share/catkin/cmake/empy.cmake:29 (message):
  Unable to find either executable 'empy' or Python module 'em'...  try
  installing the package 'python-empy'
Call Stack (most recent call first):
  /opt/ros/melodic/share/catkin/cmake/all.cmake:163 (include)
  /opt/ros/melodic/share/catkin/cmake/catkinConfig.cmake:20 (include)
  CMakeLists.txt:4 (find_package)


-- Configuring incomplete, errors occurred!
See also "/build/ros-melodic-eigen-stl-containers/src/build/CMakeFiles/CMakeOutput.log".
[1m[31m==> ERROR:[0m[1m A failure occurred in build().[0m
[1m    Aborting...[0m
```